### PR TITLE
emit errors

### DIFF
--- a/lib/coffeeify.js
+++ b/lib/coffeeify.js
@@ -192,11 +192,12 @@
                       }
                     }
                   }
-                } catch (_error) {
-                  e = _error;
+                } catch (error) {
+                  e = error;
                   traceError('coffee-script: COMPILE ERROR: ', e.message + ': line ' + (e.location.first_line + 1), 'at', filePath);
                   cacheSkip = true;
                   data = '';
+                  throw e;
                 }
               }
             }

--- a/lib/coffeeify.js
+++ b/lib/coffeeify.js
@@ -197,7 +197,7 @@
                   traceError('coffee-script: COMPILE ERROR: ', e.message + ': line ' + (e.location.first_line + 1), 'at', filePath);
                   cacheSkip = true;
                   data = '';
-                  throw e;
+                  self.emit('error', e);
                 }
               }
             }
@@ -215,8 +215,8 @@
       return b.bundle(function(err, jsCode) {
         var destFilePath, srcFilePath;
         if (err) {
-          traceError(err);
-          return;
+          traceError("browserify: BUNDLE ERROR: " + err.message);
+          self.emit('error', err);
         } else {
           file.contents = new Buffer(jsCode);
           srcFilePath = path.relative(process.cwd(), srcFile);

--- a/src/coffeeify.coffee
+++ b/src/coffeeify.coffee
@@ -75,6 +75,7 @@ module.exports = (opts = {})->
 
   # through
   through2.obj (file, enc, cb)->
+
     self = this
 
     if file.isStream()
@@ -151,8 +152,7 @@ module.exports = (opts = {})->
                 traceError 'coffee-script: COMPILE ERROR: ', e.message + ': line ' + (e.location.first_line + 1), 'at', filePath
                 cacheSkip = true
                 data = ''
-                throw e
-
+                self.emit 'error', e
           transformCache[file] = [mtime, data] unless cacheSkip
         @push data
         cb()
@@ -162,8 +162,8 @@ module.exports = (opts = {})->
     b.bundle (err, jsCode)->
 
       if err
-        traceError err
-        return
+        traceError "browserify: BUNDLE ERROR: #{err.message}"
+        self.emit 'error', err
 
       else
 
@@ -173,11 +173,11 @@ module.exports = (opts = {})->
         srcFilePath = path.relative process.cwd(), srcFile
         destFilePath = path.relative process.cwd(), destFile
 
-        # 
+        #
         gutil.log gutil.colors.green "coffeeify: #{srcFilePath} > #{destFilePath}"
 
         file.path = destFile
         self.push file
-      
+
       # callback
       cb()

--- a/src/coffeeify.coffee
+++ b/src/coffeeify.coffee
@@ -151,6 +151,7 @@ module.exports = (opts = {})->
                 traceError 'coffee-script: COMPILE ERROR: ', e.message + ': line ' + (e.location.first_line + 1), 'at', filePath
                 cacheSkip = true
                 data = ''
+                throw e
 
           transformCache[file] = [mtime, data] unless cacheSkip
         @push data


### PR DESCRIPTION
Errors during coffeescript compilation and browserify bundle are logged and swallowed.  Implementing gulp scripts read this as a success and carry on with further work, and eventually exit with status 0.

Errors should should be emitted per the gulp docs
https://github.com/gulpjs/gulp/blob/master/docs/writing-a-plugin/dealing-with-streams.md
This allows scripts to detect errors and halt, or handle them appropriately.

Also, errors during bundle would return rather than calling the callback, which halts the whole script.
